### PR TITLE
Fix nesting issue for refs in sidebar component

### DIFF
--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -25,6 +25,7 @@ import { createContext } from './context';
 import Store, { Options } from './store';
 import getInitialState from './initial-state';
 import type { StoriesHash, Story, Root, Group } from './lib/stories';
+import type { ComposedRef } from './modules/refs';
 import { isGroup, isRoot, isStory } from './lib/stories';
 
 import * as provider from './modules/provider';
@@ -328,7 +329,7 @@ export function useStorybookApi(): API {
   return api;
 }
 
-export type { StoriesHash, Story, Root, Group };
+export type { StoriesHash, Story, Root, Group, ComposedRef };
 export { ManagerConsumer as Consumer, ManagerProvider as Provider, isGroup, isRoot, isStory };
 
 export interface EventMap {

--- a/lib/ui/src/components/sidebar/Sidebar.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useMemo } from 'react';
 
 import { styled } from '@storybook/theming';
 import { ScrollArea, Spaced } from '@storybook/components';
-import type { StoriesHash, State } from '@storybook/api';
+import type { StoriesHash, State, ComposedRef } from '@storybook/api';
 
 import { Heading } from './Heading';
 
@@ -100,11 +100,9 @@ export const Sidebar: FunctionComponent<SidebarProps> = React.memo(
     enableShortcuts = true,
     refs = {},
   }) => {
+    const collapseFn = DOCS_MODE ? collapseAllStories : collapseDocsOnlyStories;
     const selected: Selection = useMemo(() => storyId && { storyId, refId }, [storyId, refId]);
-    const stories = useMemo(
-      () => (DOCS_MODE ? collapseAllStories : collapseDocsOnlyStories)(storiesHash),
-      [DOCS_MODE, storiesHash]
-    );
+    const stories = useMemo(() => collapseFn(storiesHash), [DOCS_MODE, storiesHash]);
 
     const adaptedRefs = useMemo(() => {
       return Object.entries(refs).reduce((acc: Refs, [id, ref]: [string, ComposedRef]) => {

--- a/lib/ui/src/components/sidebar/Sidebar.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.tsx
@@ -105,23 +105,21 @@ export const Sidebar: FunctionComponent<SidebarProps> = React.memo(
       () => (DOCS_MODE ? collapseAllStories : collapseDocsOnlyStories)(storiesHash),
       [DOCS_MODE, storiesHash]
     );
+
     const adaptedRefs = useMemo(() => {
-      if (DOCS_MODE) {
-        return Object.keys(refs).reduce((acc: Refs, cur) => {
-          const ref = refs[cur];
-          if (ref.stories) {
-            acc[cur] = {
-              ...ref,
-              stories: collapseDocsOnlyStories(ref.stories),
-            };
-          } else {
-            acc[cur] = ref;
-          }
-          return acc;
-        }, {});
-      }
-      return refs;
+      return Object.entries(refs).reduce((acc: Refs, [id, ref]: [string, ComposedRef]) => {
+        if (ref.stories) {
+          acc[id] = {
+            ...ref,
+            stories: collapseFn(ref.stories),
+          };
+        } else {
+          acc[id] = ref;
+        }
+        return acc;
+      }, {});
     }, [DOCS_MODE, refs]);
+
     const dataset = useCombination(stories, storiesConfigured, storiesFailed, adaptedRefs);
     const isLoading = !dataset.hash[DEFAULT_REF_ID].ready;
     const lastViewedProps = useLastViewed(selected);


### PR DESCRIPTION
## Issue:
Refs were being handled differently than stories for Storybook Composition. This caused unnecessary nesting in the Sidebar component:

| External View | Internal View |
| ---------------------- | -- |
![image](https://user-images.githubusercontent.com/40154944/158522121-1c8918ed-ce6e-4e20-bf39-e2ac4bcb49c2.png) | ![image](https://user-images.githubusercontent.com/40154944/158522145-e5ef5178-1fd0-445d-898d-6d7594cfa193.png) |

This PR ensures the external refs are handled and displayed the same way as viewing the storybook directly.

